### PR TITLE
Plan `list` command

### DIFF
--- a/.agents/plans/004-list-command/000-plan.md
+++ b/.agents/plans/004-list-command/000-plan.md
@@ -1,0 +1,48 @@
+# Surface Template Catalog via `list`
+
+## Brief
+
+Design the work to introduce an `nmcr list` command that loads the project's template catalog, keeps tree member files associated with their parent trees, and prints both tree and standalone file templates with key metadata in a readable hierarchy.
+
+## Plan
+
+- [ ] [Share catalog parsing via new crate](.agents/plans/004-list-command/001-share-catalog-parsing.md): Refactor the template catalog builder into a reusable `nmcr_catalog` crate consumed by both the CLI and MCP crates while keeping tree member files attached to their parent tree definitions.
+- [ ] [Add CLI command to render catalog](.agents/plans/004-list-command/002-add-cli-list-command.md): Define the `list` subcommand, load the catalog via the shared API, and render tree/file templates with indentation and metadata without duplicating tree member files at the root level.
+- [ ] [Test and document the listing flow](.agents/plans/004-list-command/003-test-and-document.md): Cover catalog tree membership handling and CLI output with automated tests and update docs or help text to describe the new command.
+
+## Steps
+
+### [Share catalog parsing via new crate](.agents/plans/004-list-command/001-share-catalog-parsing.md)
+
+Build a shared catalog module inside the new `nmcr_catalog` crate that keeps tree file templates scoped to their parent trees, exposes ID lookup helpers that walk tree members when needed, and remains usable from both the CLI and MCP call sites.
+
+### [Add CLI command to render catalog](.agents/plans/004-list-command/002-add-cli-list-command.md)
+
+Implement an `nmcr list` command that loads the catalog, prints trees with their files indented alongside ids, paths, descriptions, and args, and ensures each tree file shows its full ID without appearing at the top level.
+
+### [Test and document the listing flow](.agents/plans/004-list-command/003-test-and-document.md)
+
+Ensure tree membership handling and CLI rendering are covered by tests and reflect the new command in user-facing documentation or help output.
+
+## Questions
+
+None.
+
+## Notes
+
+- Ensure tree member files carry their tree-scoped IDs without duplicating them at the root level, keeping duplicate ID detection straightforward.
+- Tree templates may aggregate args from member files; plan to show whichever metadata the shared catalog exposes without inventing new fields.
+- Follow existing CLI output styling conventions (e.g., indentation, bullet markers) when formatting the list.
+- Provide shared helper functions so CLI and MCP code can look up template IDs by checking tree members when the ID prefix matches the tree ID.
+
+## Prompt
+
+I want you to plan `list` command feature. It should load project catalog and then print file and tree templates with their data: id, path, description and args (tree templates will not have all the data). Render tree templates with their file templates indented. When parsing templates catalog, add flag `nested` and when rendering the list filter out these templates as they will be rendered as a part of the tree templates.
+
+### Follow-Ups
+
+Make sure the tree's file templates have the correct id assigned, but ditch adding templates to the root level. This will make special case for id checking unncessary.
+
+Change template id lookup (both in gen and mcp, so use shared functionality; create crate `nmcr_catalog` at `pkgs/catalog`) to check inside tree's files (since tree's file ids starts with tree's id, it is possible to skip iterating unless specified id starts with the tree id).
+
+We won't need `nested` flag then.

--- a/.agents/plans/004-list-command/001-share-catalog-parsing.md
+++ b/.agents/plans/004-list-command/001-share-catalog-parsing.md
@@ -1,0 +1,26 @@
+# Share catalog parsing via new crate
+
+## Objective
+
+Stand up a reusable `nmcr_catalog` crate that loads template catalogs with tree members scoped to their parent tree definitions and exposes helpers for ID lookup so both the generator and MCP paths can consume the shared logic without relying on a `nested` flag.
+
+## Tasks
+
+- [ ] **Audit current catalog assembly** — locate the existing catalog-loading and ID lookup code paths in the CLI generator and MCP crates to catalogue what must be shared.
+      Document any implicit behaviors around tree/file relationships so they can be preserved when refactoring.
+- [ ] **Scaffold `pkgs/catalog` crate** — create the new package (Cargo manifest, lib module, feature flags) and move or re-export the template catalog data structures so they can be imported from both consumers.
+      Ensure the crate exposes stable types for tree templates that carry member file lists with fully qualified IDs.
+- [ ] **Centralize parsing logic** — extract the template loading routines into the crate, keeping file templates attached to their tree parents rather than flattening them at the root level.
+      Provide constructors that validate duplicate IDs by walking tree members without needing a `nested` marker.
+- [ ] **Implement shared ID lookup helpers** — add functions that resolve templates by ID, checking tree member files when the requested ID shares a prefix with the tree ID.
+      Update generator and MCP call sites to use these helpers instead of their local implementations.
+- [ ] **Cover crate behavior with tests** — add unit tests verifying tree-scoped IDs, duplicate ID detection, and lookup behavior so regressions surface quickly when consumers change.
+      Include fixtures mirroring existing catalog examples to ensure parity after the move.
+
+## Questions
+
+None.
+
+## Notes
+
+Keep the crate free of CLI-specific concerns so it can be reused by additional tools in the future.

--- a/.agents/plans/004-list-command/002-add-cli-list-command.md
+++ b/.agents/plans/004-list-command/002-add-cli-list-command.md
@@ -1,0 +1,26 @@
+# Add CLI command to render catalog
+
+## Objective
+
+Introduce an `nmcr list` subcommand that loads the shared catalog, prints tree templates with their member files indented beneath them, and surfaces metadata (ID, path, description, args) without showing tree members twice.
+
+## Tasks
+
+- [ ] **Define command interface** — extend the CLI argument parser to register a `list` subcommand with help text describing the catalog output.
+      Confirm the command can coexist with existing options and follows the project's CLI conventions.
+- [ ] **Load catalog via `nmcr_catalog`** — invoke the shared crate to build the catalog when the command runs, reusing its error types for missing or invalid template data.
+      Handle initialization failures gracefully so the command exits with a helpful message.
+- [ ] **Format tree-first output** — iterate over tree templates, printing each tree's ID, path, description, and args summary followed by its file templates indented underneath.
+      Ensure standalone file templates appear once at the root level and tree members only appear inside their tree block.
+- [ ] **Render metadata consistently** — decide on field ordering, indentation, and styling (e.g., bullet markers) that mirror other CLI listings.
+      Include arguments only when present and fall back to placeholders where tree metadata is incomplete.
+- [ ] **Wire into CLI entry point** — connect the new subcommand to the main command dispatch flow and ensure exit codes reflect success or failure of catalog rendering.
+      Add logging or verbose output hooks if the project expects them for debugging.
+
+## Questions
+
+None.
+
+## Notes
+
+Reuse the shared ID lookup helpers when cross-referencing IDs during rendering to avoid duplicating traversal logic.

--- a/.agents/plans/004-list-command/003-test-and-document.md
+++ b/.agents/plans/004-list-command/003-test-and-document.md
@@ -1,0 +1,26 @@
+# Test and document the listing flow
+
+## Objective
+
+Validate the shared catalog behavior and the `nmcr list` command output while updating documentation so users understand how to inspect available templates.
+
+## Tasks
+
+- [ ] **Expand catalog unit tests** — exercise the `nmcr_catalog` crate with scenarios covering tree member IDs, duplicate detection, and lookup helpers.
+      Include cases for both matching and non-matching tree prefixes to guard against regressions.
+- [ ] **Add CLI integration coverage** — write tests (or golden-output fixtures) that execute `nmcr list` against a sample catalog and assert the rendered hierarchy and metadata formatting.
+      Verify standalone file templates and tree members appear exactly once in the expected order.
+- [ ] **Update user-facing docs** — revise CLI help text, README sections, or docs site pages to describe the new `list` command and explain the tree-plus-file hierarchy.
+      Mention how IDs relate between trees and their member files so users can map output to generator inputs.
+- [ ] **Confirm developer workflows** — ensure MCP and generator flows continue to resolve template IDs correctly after adopting the shared crate.
+      Run or script smoke tests that mimic their lookups to catch regressions beyond the CLI path.
+- [ ] **Document follow-up considerations** — note any future enhancements (e.g., sorting, filtering) discovered while testing so they can be tracked separately without blocking release.
+      Capture gaps or edge cases the current scope intentionally leaves unresolved.
+
+## Questions
+
+None.
+
+## Notes
+
+Coordinate with documentation maintainers if additional guides or release notes are required.


### PR DESCRIPTION
Design the work to introduce an `nmcr list` command that loads the project's template catalog, keeps tree member files associated with their parent trees, and prints both tree and standalone file templates with key metadata in a readable hierarchy.

------
https://chatgpt.com/codex/tasks/task_e_68d89fc4b59883248bb9363a60ba0bcb